### PR TITLE
Security group rules don’t have a `name` parameter

### DIFF
--- a/cloudstack/resource_cloudstack_security_group_rule.go
+++ b/cloudstack/resource_cloudstack_security_group_rule.go
@@ -320,7 +320,7 @@ func resourceCloudStackSecurityGroupRuleRead(d *schema.ResourceData, meta interf
 	)
 	if err != nil {
 		if count == 0 {
-			log.Printf("[DEBUG] Security group %s does not longer exist", d.Get("name").(string))
+			log.Printf("[DEBUG] Security group %s does not longer exist", d.Id())
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
Fixes #2