### PR TITLE
docs: add previously undocumented attributes

### DIFF
--- a/website/docs/r/ipaddress.html.markdown
+++ b/website/docs/r/ipaddress.html.markdown
@@ -28,6 +28,9 @@ The following arguments are supported:
 * `vpc_id` - (Optional) The ID of the VPC for which an IP address should be
    acquired and associated. Changing this forces a new resource to be created.
 
+* `zone_id` - (Optional) The ID of the zone for which an IP address should be
+   acquired and associated. Changing this forces a new resource to be created.
+
 * `project` - (Optional) The name or ID of the project to deploy this
     instance to. Changing this forces a new resource to be created.
 

--- a/website/docs/r/port_forward.html.markdown
+++ b/website/docs/r/port_forward.html.markdown
@@ -32,6 +32,9 @@ The following arguments are supported:
 * `ip_address_id` - (Required) The IP address ID for which to create the port
     forwards. Changing this forces a new resource to be created.
 
+* `project` - (Optional) The name or ID of the project to register this
+    affinity group to. Changing this forces a new resource to be created.
+
 * `managed` - (Optional) USE WITH CAUTION! If enabled all the port forwards for
     this IP address will be managed by this resource. This means it will delete
     all port forwards that are not in your config! (defaults false)

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -39,6 +39,12 @@ The following arguments are supported:
 * `security_group_id` - (Required) The security group ID for which to create
     the rules. Changing this forces a new resource to be created.
 
+* `project` - (Optional) The name or ID of the project to register this
+    affinity group to. Changing this forces a new resource to be created.
+
+* `parallelism` (Optional) Specifies how much rules will be created or deleted
+    concurrently. (defaults 2)
+
 * `rule` - (Required) Can be specified multiple times. Each rule block supports
     fields documented below.
 


### PR DESCRIPTION
this PR adds missing documentation to three resources:

- ipaddress
- portforward
- security_group_rule