### PR TITLE
add tags in resources vpc, instance, ipadress, template and vpc

### DIFF
--- a/cloudstack/resource_cloudstack_disk.go
+++ b/cloudstack/resource_cloudstack_disk.go
@@ -116,6 +116,13 @@ func resourceCloudStackDiskCreate(d *schema.ResourceData, meta interface{}) erro
 
 	// Set the volume ID and partials
 	d.SetId(r.Id)
+
+	// Put tags if necessary
+	err = setTags(cs, d, "Volume")
+	if err != nil {
+		return fmt.Errorf("Error setting tags on the new instance %s: %s", name, err)
+	}
+
 	d.SetPartial("name")
 	d.SetPartial("device_id")
 	d.SetPartial("disk_offering")
@@ -243,6 +250,13 @@ func resourceCloudStackDiskUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.Partial(false)
+
+	// Update tags if they have changed
+	err := updateTags(cs, d, "Volume")
+	if err != nil {
+		return fmt.Errorf("Error setting tags on the disk %s: %s", name, err)
+	}
+
 	return resourceCloudStackDiskRead(d, meta)
 }
 

--- a/cloudstack/resource_cloudstack_disk.go
+++ b/cloudstack/resource_cloudstack_disk.go
@@ -68,6 +68,8 @@ func resourceCloudStackDisk() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -120,7 +122,7 @@ func resourceCloudStackDiskCreate(d *schema.ResourceData, meta interface{}) erro
 	// Put tags if necessary
 	err = setTags(cs, d, "Volume")
 	if err != nil {
-		return fmt.Errorf("Error setting tags on the new instance %s: %s", name, err)
+		return fmt.Errorf("Error setting tags on the new disk %s: %s", name, err)
 	}
 
 	d.SetPartial("name")
@@ -254,7 +256,7 @@ func resourceCloudStackDiskUpdate(d *schema.ResourceData, meta interface{}) erro
 	// Update tags if they have changed
 	err := updateTags(cs, d, "Volume")
 	if err != nil {
-		return fmt.Errorf("Error setting tags on the disk %s: %s", name, err)
+		return fmt.Errorf("Error updating tags on the disk %s: %s", name, err)
 	}
 
 	return resourceCloudStackDiskRead(d, meta)

--- a/cloudstack/resource_cloudstack_disk_test.go
+++ b/cloudstack/resource_cloudstack_disk_test.go
@@ -23,6 +23,7 @@ func TestAccCloudStackDisk_basic(t *testing.T) {
 					testAccCheckCloudStackDiskExists(
 						"cloudstack_disk.foo", &disk),
 					testAccCheckCloudStackDiskAttributes(&disk),
+					testAccCheckResourceTags(&disk),
 				),
 			},
 		},
@@ -166,6 +167,9 @@ resource "cloudstack_disk" "foo" {
   attach = false
   disk_offering = "%s"
   zone = "%s"
+  tags = {
+	terraform-tag = "true"
+  }
 }`,
 	CLOUDSTACK_DISK_OFFERING_1,
 	CLOUDSTACK_ZONE)

--- a/cloudstack/resource_cloudstack_instance.go
+++ b/cloudstack/resource_cloudstack_instance.go
@@ -549,7 +549,7 @@ func resourceCloudStackInstanceUpdate(d *schema.ResourceData, meta interface{}) 
 	// Update tags if they have changed
 	err := updateTags(cs, d, "userVm")
 	if err != nil {
-		return fmt.Errorf("Error setting tags on the instance %s: %s", name, err)
+		return fmt.Errorf("Error updating tags on the instance %s: %s", name, err)
 	}
 
 	return resourceCloudStackInstanceRead(d, meta)

--- a/cloudstack/resource_cloudstack_instance.go
+++ b/cloudstack/resource_cloudstack_instance.go
@@ -140,6 +140,8 @@ func resourceCloudStackInstance() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -269,6 +271,12 @@ func resourceCloudStackInstanceCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.SetId(r.Id)
+
+	// Put tags if necessary
+	err = setTags(cs, d, "userVm")
+	if err != nil {
+		return fmt.Errorf("Error setting tags on the new instance %s: %s", name, err)
+	}
 
 	// Set the connection info for any configured provisioners
 	d.SetConnInfo(map[string]string{
@@ -536,8 +544,13 @@ func resourceCloudStackInstanceUpdate(d *schema.ResourceData, meta interface{}) 
 				"Error starting instance %s after making changes", name)
 		}
 	}
-
 	d.Partial(false)
+
+	// Update tags if they have changed
+	err := updateTags(cs, d, "userVm")
+	if err != nil {
+		return fmt.Errorf("Error setting tags on the instance %s: %s", name, err)
+	}
 
 	return resourceCloudStackInstanceRead(d, meta)
 }

--- a/cloudstack/resource_cloudstack_instance_test.go
+++ b/cloudstack/resource_cloudstack_instance_test.go
@@ -25,6 +25,7 @@ func TestAccCloudStackInstance_basic(t *testing.T) {
 					testAccCheckCloudStackInstanceAttributes(&instance),
 					resource.TestCheckResourceAttr(
 						"cloudstack_instance.foobar", "user_data", "0cf3dcdc356ec8369494cb3991985ecd5296cdd5"),
+					testAccCheckResourceTags(&instance),
 				),
 			},
 		},
@@ -239,6 +240,9 @@ resource "cloudstack_instance" "foobar" {
   zone = "%s"
   user_data = "foobar\nfoo\nbar"
   expunge = true
+  tags = {
+	terraform-tag = "true"
+  }
 }`,
 	CLOUDSTACK_SERVICE_OFFERING_1,
 	CLOUDSTACK_NETWORK_1,

--- a/cloudstack/resource_cloudstack_ipaddress.go
+++ b/cloudstack/resource_cloudstack_ipaddress.go
@@ -52,6 +52,8 @@ func resourceCloudStackIPAddress() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -103,6 +105,12 @@ func resourceCloudStackIPAddressCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	d.SetId(r.Id)
+
+	// Put tags if necessary
+	err = setTags(cs, d, "PublicIpAddress")
+	if err != nil {
+		return fmt.Errorf("Error setting tags on the IP address: %s", err)
+	}
 
 	return resourceCloudStackIPAddressRead(d, meta)
 }

--- a/cloudstack/resource_cloudstack_ipaddress_test.go
+++ b/cloudstack/resource_cloudstack_ipaddress_test.go
@@ -23,6 +23,7 @@ func TestAccCloudStackIPAddress_basic(t *testing.T) {
 					testAccCheckCloudStackIPAddressExists(
 						"cloudstack_ipaddress.foo", &ipaddr),
 					testAccCheckCloudStackIPAddressAttributes(&ipaddr),
+					testAccCheckResourceTags(&ipaddr),
 				),
 			},
 		},
@@ -113,6 +114,9 @@ func testAccCheckCloudStackIPAddressDestroy(s *terraform.State) error {
 var testAccCloudStackIPAddress_basic = fmt.Sprintf(`
 resource "cloudstack_ipaddress" "foo" {
   network_id = "%s"
+  tags = {
+	terraform-tag = "true"
+  }
 }`, CLOUDSTACK_NETWORK_1)
 
 var testAccCloudStackIPAddress_vpc = fmt.Sprintf(`

--- a/cloudstack/resource_cloudstack_network_test.go
+++ b/cloudstack/resource_cloudstack_network_test.go
@@ -23,7 +23,7 @@ func TestAccCloudStackNetwork_basic(t *testing.T) {
 					testAccCheckCloudStackNetworkExists(
 						"cloudstack_network.foo", &network),
 					testAccCheckCloudStackNetworkBasicAttributes(&network),
-					testAccCheckNetworkTags(&network, "terraform-tag", "true"),
+					testAccCheckResourceTags(&network),
 				),
 			},
 		},
@@ -129,17 +129,6 @@ func testAccCheckCloudStackNetworkBasicAttributes(
 		}
 
 		return nil
-	}
-}
-
-func testAccCheckNetworkTags(
-	n *cloudstack.Network, key string, value string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		tags := make(map[string]string)
-		for item := range n.Tags {
-			tags[n.Tags[item].Key] = n.Tags[item].Value
-		}
-		return testAccCheckTags(tags, key, value)
 	}
 }
 

--- a/cloudstack/resource_cloudstack_template.go
+++ b/cloudstack/resource_cloudstack_template.go
@@ -106,6 +106,8 @@ func resourceCloudStackTemplate() *schema.Resource {
 				Optional: true,
 				Default:  300,
 			},
+
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -180,6 +182,12 @@ func resourceCloudStackTemplateCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.SetId(r.RegisterTemplate[0].Id)
+
+	// Put tags if necessary
+	err = setTags(cs, d, "Template")
+	if err != nil {
+		return fmt.Errorf("Error setting tags on the template %s: %s", name, err)
+	}
 
 	// Wait until the template is ready to use, or timeout with an error...
 	currentTime := time.Now().Unix()
@@ -277,7 +285,13 @@ func resourceCloudStackTemplateUpdate(d *schema.ResourceData, meta interface{}) 
 		p.SetPasswordenabled(d.Get("password_enabled").(bool))
 	}
 
-	_, err := cs.Template.UpdateTemplate(p)
+	// Update tags if necessary
+	err := updateTags(cs, d, "Template")
+	if err != nil {
+		return fmt.Errorf("Error updating tags on the template %s: %s", name, err)
+	}
+
+	_, err = cs.Template.UpdateTemplate(p)
 	if err != nil {
 		return fmt.Errorf("Error updating template %s: %s", name, err)
 	}

--- a/cloudstack/resource_cloudstack_template_test.go
+++ b/cloudstack/resource_cloudstack_template_test.go
@@ -24,6 +24,7 @@ func TestAccCloudStackTemplate_basic(t *testing.T) {
 					testAccCheckCloudStackTemplateBasicAttributes(&template),
 					resource.TestCheckResourceAttr(
 						"cloudstack_template.foo", "display_text", "terraform-test"),
+					testAccCheckResourceTags(&template),
 				),
 			},
 		},
@@ -166,6 +167,9 @@ resource "cloudstack_template" "foo" {
 	os_type = "%s"
 	url = "%s"
   zone = "%s"
+  tags = {
+	terraform-tag = "true"
+  }
 }
 `,
 	CLOUDSTACK_TEMPLATE_FORMAT,

--- a/cloudstack/resource_cloudstack_vpc.go
+++ b/cloudstack/resource_cloudstack_vpc.go
@@ -64,6 +64,8 @@ func resourceCloudStackVPC() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -118,6 +120,12 @@ func resourceCloudStackVPCCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	d.SetId(r.Id)
+
+	// Put tags if necessary
+	err = setTags(cs, d, "Vpc")
+	if err != nil {
+		return fmt.Errorf("Error setting tags on the VPC: %s", err)
+	}
 
 	return resourceCloudStackVPCRead(d, meta)
 }
@@ -220,6 +228,12 @@ func resourceCloudStackVPCUpdate(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf(
 				"Error updating display test of VPC %s: %s", name, err)
 		}
+	}
+
+	// Update tags if necessary
+	err := setTags(cs, d, "Vpc")
+	if err != nil {
+		return fmt.Errorf("Error updating tags on the VPC: %s", err)
 	}
 
 	return resourceCloudStackVPCRead(d, meta)

--- a/cloudstack/resource_cloudstack_vpc_test.go
+++ b/cloudstack/resource_cloudstack_vpc_test.go
@@ -25,6 +25,7 @@ func TestAccCloudStackVPC_basic(t *testing.T) {
 					testAccCheckCloudStackVPCAttributes(&vpc),
 					resource.TestCheckResourceAttr(
 						"cloudstack_vpc.foo", "vpc_offering", CLOUDSTACK_VPC_OFFERING),
+					testAccCheckResourceTags(&vpc),
 				),
 			},
 		},

--- a/cloudstack/tags.go
+++ b/cloudstack/tags.go
@@ -51,6 +51,15 @@ func setTags(cs *cloudstack.CloudStackClient, d *schema.ResourceData, resourcety
 	return nil
 }
 
+// setTags is an helper to update only when tags field change
+// tags field to be named "tags"
+func updateTags(cs *cloudstack.CloudStackClient, d *schema.ResourceData, resourcetype string) error {
+	if !d.HasChange("tags") {
+		return nil
+	}
+	return setTags(cs, d, resourcetype)
+}
+
 // diffTags takes the old and the new tag sets and returns the difference of
 // both. The remaining tags are those that need to be removed and created
 func diffTags(oldTags, newTags map[string]string) (map[string]string, map[string]string) {


### PR DESCRIPTION
User could tags only network, I've added tags parameter to more cloudstack resource.

Actually we can tags everything except security group but api docs about [tags](http://cloudstack.apache.org/docs/api/apidocs-4.8/root_admin/createTags.html) ask for `resourceType` and their is no simple way to know what can be this values.

I've found some of them and added the tags parameter.

There is a refactoring to test tags in resource.

Finally, I couldn't run acceptance tests only because I'm not sure what should inside env vars and how it could affect my cloudstack. 
Maybe just some comments could help