### PR TITLE
cloudstack_ipaddress: do not use a non existing parameter

### DIFF
--- a/cloudstack/resource_cloudstack_ipaddress.go
+++ b/cloudstack/resource_cloudstack_ipaddress.go
@@ -158,7 +158,7 @@ func resourceCloudStackIPAddressDelete(d *schema.ResourceData, meta interface{})
 			return nil
 		}
 
-		return fmt.Errorf("Error disassociating IP address %s: %s", d.Get("name").(string), err)
+		return fmt.Errorf("Error disassociating IP address %s: %s", d.Id(), err)
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #17