### PR TITLE
ipaddress: set is_portable

### DIFF
--- a/cloudstack/resource_cloudstack_ipaddress.go
+++ b/cloudstack/resource_cloudstack_ipaddress.go
@@ -126,6 +126,8 @@ func resourceCloudStackIPAddressRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
+	d.Set("is_portable", ip.Isportable)
+
 	// Updated the IP address
 	d.Set("ip_address", ip.Ipaddress)
 


### PR DESCRIPTION
resourceCloudStackIPAddressRead() does not set is_portable.
