### PR TITLE
Add datasource cloudstack_template

### DIFF
--- a/cloudstack/data_source_cloudstack_common_schema.go
+++ b/cloudstack/data_source_cloudstack_common_schema.go
@@ -7,7 +7,7 @@ import (
 func dataSourceFiltersSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeSet,
-		Optional: true,
+		Required: true,
 		ForceNew: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{

--- a/cloudstack/data_source_cloudstack_common_schema.go
+++ b/cloudstack/data_source_cloudstack_common_schema.go
@@ -1,0 +1,25 @@
+package cloudstack
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceFiltersSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		ForceNew: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"value": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}

--- a/cloudstack/data_source_cloudstack_template.go
+++ b/cloudstack/data_source_cloudstack_template.go
@@ -1,0 +1,124 @@
+package cloudstack
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/xanzy/go-cloudstack/cloudstack"
+	"log"
+	"regexp"
+	"time"
+)
+
+func dataSourceCloudstackTemplate() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceCloudstackTemplateRead,
+		Schema: map[string]*schema.Schema{
+			"displaytext_regex": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"templatefilter": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			// Computed values
+			"template_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"account": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"displaytext": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"format": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"hypervisor": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"size": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func dataSourceCloudstackTemplateRead(d *schema.ResourceData, meta interface{}) error {
+	cs := meta.(*cloudstack.CloudStackClient)
+	ltp := cloudstack.ListTemplatesParams{}
+	ltp.SetListall(true)
+	ltp.SetTemplatefilter(d.Get("templatefilter").(string))
+	csTemplates, err := cs.Template.ListTemplates(&ltp)
+	if err != nil {
+		log.Printf("[ERROR] Failed to list templates: %s", err)
+	}
+	r := regexp.MustCompile(d.Get("displaytext_regex").(string))
+	var templates []*cloudstack.Template
+
+	for _, t := range csTemplates.Templates {
+		if r.Match([]byte(t.Displaytext)) {
+			templates = append(templates, t)
+		}
+	}
+
+	var template *cloudstack.Template
+
+	if len(templates) > 1 {
+		template = mostRecentTemplate(templates)
+	} else if len(templates) == 1 {
+		template = templates[0]
+	} else {
+		return fmt.Errorf("No template is matching with the specified regex.\n")
+	}
+	return templateDescriptionAttributes(d, template)
+}
+
+func templateDescriptionAttributes(d *schema.ResourceData, template *cloudstack.Template) error {
+	d.SetId(template.Id)
+	d.Set("template_id", template.Id)
+	d.Set("account", template.Account)
+	d.Set("created", template.Created)
+	d.Set("displaytext", template.Displaytext)
+	d.Set("format", template.Format)
+	d.Set("hypervisor", template.Hypervisor)
+	d.Set("name", template.Name)
+	d.Set("size", template.Size)
+	d.Set("tags", template.Tags)
+	return nil
+}
+
+func mostRecentTemplate(templates []*cloudstack.Template) *cloudstack.Template {
+	var mrt int
+	mostRecent := int64(0)
+	for k, t := range templates {
+		created, err := time.Parse("2006-01-02T15:04:05-0700", t.Created)
+		if err != nil {
+			panic(err)
+		}
+
+		if created.Unix() > mostRecent {
+			mostRecent = created.Unix()
+			mrt = k
+		}
+	}
+
+	log.Printf("[DEBUG] Most recent template selected: %+v\n", templates[mrt])
+	return templates[mrt]
+}

--- a/cloudstack/provider.go
+++ b/cloudstack/provider.go
@@ -58,6 +58,10 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"cloudstack_template": dataSourceCloudstackTemplate(),
+		},
+
 		ResourcesMap: map[string]*schema.Resource{
 			"cloudstack_affinity_group":       resourceCloudStackAffinityGroup(),
 			"cloudstack_disk":                 resourceCloudStackDisk(),


### PR DESCRIPTION
This datasource allows you to retrieve a template according to filters you set.
There can be several versions for one template, the datasource will always returns the most recent one.

### Parameters:

* `templatefilter` is needed according to the Cloudstack API (https://cloudstack.apache.org/api/apidocs-4.9/apis/listTemplates.html).
* `filter` is used to sort templates.

If you set a `filter`, the datasource will only returns templates where the field `name` has the value `value` (the value can be a regex).
To see the list of available options, check the Template struct of the Cloudstack client : https://godoc.org/github.com/xanzy/go-cloudstack/cloudstack#Template 

### Example:
```
data "cloudstack_template" "my_template" {
    templatefilter = "featured"
    filter {
        name = "name"
        value = "CentOS 7\\.1"
    }
    filter {
        name = "hypervisor"
        value = "KVM"
    }
}
```

### Note:

At the moment, filters only work with string fields, you will not be able to set options like `size`, `tags` or `bootable`.