### PR TITLE
Add Load Balancer Rule protocol support

### DIFF
--- a/cloudstack/resource_cloudstack_loadbalancer_rule.go
+++ b/cloudstack/resource_cloudstack_loadbalancer_rule.go
@@ -57,6 +57,12 @@ func resourceCloudStackLoadBalancerRule() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"protocol": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"member_ids": &schema.Schema{
 				Type:     schema.TypeSet,
 				Required: true,
@@ -102,6 +108,11 @@ func resourceCloudStackLoadBalancerRuleCreate(d *schema.ResourceData, meta inter
 		p.SetNetworkid(networkid.(string))
 	}
 
+	// Set the protocol
+	if protocol, ok := d.GetOk("protocol"); ok {
+		p.SetProtocol(protocol.(string))
+	}
+
 	// Set the ipaddress id
 	p.SetPublicipid(d.Get("ip_address_id").(string))
 
@@ -120,6 +131,7 @@ func resourceCloudStackLoadBalancerRuleCreate(d *schema.ResourceData, meta inter
 	d.SetPartial("algorithm")
 	d.SetPartial("private_port")
 	d.SetPartial("public_port")
+	d.SetPartial("protocol")
 
 	// Create a new parameter struct
 	ap := cs.LoadBalancer.NewAssignToLoadBalancerRuleParams(r.Id)
@@ -168,6 +180,11 @@ func resourceCloudStackLoadBalancerRuleRead(d *schema.ResourceData, meta interfa
 	// Only set network if user specified it to avoid spurious diffs
 	if _, ok := d.GetOk("network_id"); ok {
 		d.Set("network_id", lb.Networkid)
+	}
+
+	// Only set protocol if user specified it to avoid spurious diffs
+	if _, ok := d.GetOk("protocol"); ok {
+		d.Set("protocol", lb.Protocol)
 	}
 
 	setValueOrID(d, "project", lb.Project, lb.Projectid)

--- a/cloudstack/resource_cloudstack_loadbalancer_rule.go
+++ b/cloudstack/resource_cloudstack_loadbalancer_rule.go
@@ -61,6 +61,7 @@ func resourceCloudStackLoadBalancerRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 
 			"member_ids": &schema.Schema{
@@ -176,15 +177,11 @@ func resourceCloudStackLoadBalancerRuleRead(d *schema.ResourceData, meta interfa
 	d.Set("public_port", lb.Publicport)
 	d.Set("private_port", lb.Privateport)
 	d.Set("ip_address_id", lb.Publicipid)
+	d.Set("protocol", lb.Protocol)
 
 	// Only set network if user specified it to avoid spurious diffs
 	if _, ok := d.GetOk("network_id"); ok {
 		d.Set("network_id", lb.Networkid)
-	}
-
-	// Only set protocol if user specified it to avoid spurious diffs
-	if _, ok := d.GetOk("protocol"); ok {
-		d.Set("protocol", lb.Protocol)
 	}
 
 	setValueOrID(d, "project", lb.Project, lb.Projectid)

--- a/cloudstack/resource_cloudstack_loadbalancer_rule_test.go
+++ b/cloudstack/resource_cloudstack_loadbalancer_rule_test.go
@@ -108,6 +108,8 @@ func TestAccCloudStackLoadBalancerRule_forceNew(t *testing.T) {
 						"cloudstack_loadbalancer_rule.foo", "public_port", "443"),
 					resource.TestCheckResourceAttr(
 						"cloudstack_loadbalancer_rule.foo", "private_port", "443"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_loadbalancer_rule.foo", "protocol", "tcp-proxy"),
 				),
 			},
 		},
@@ -307,6 +309,7 @@ resource "cloudstack_loadbalancer_rule" "foo" {
   algorithm = "leastconn"
   public_port = 443
   private_port = 443
+  protocol = "tcp-proxy"
   member_ids = ["${cloudstack_instance.foobar1.id}"]
 }
 `,

--- a/website/docs/r/loadbalancer_rule.html.markdown
+++ b/website/docs/r/loadbalancer_rule.html.markdown
@@ -52,6 +52,9 @@ The following arguments are supported:
     will be load balanced from. Changing this forces a new resource to be
     created.
 
+* `protocol` - (Optional) Load balancer protocol (tcp, udp, tcp-proxy).
+    Changing this forces a new resource to be created.
+
 * `member_ids` - (Required) List of instance IDs to assign to the load balancer
     rule. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
This adds support for the Load Balancer Rule `protocol` field, added in CloudStack 4.3. The primary use of this optional field is to specify a protocol of `tcp-proxy`, which enables [`PROXY` protocol headers](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) to be sent to the load balanced instance(s).