### PR TITLE
instance: volume is in Byte rather than GiB

### DIFF
--- a/cloudstack/resource_cloudstack_instance.go
+++ b/cloudstack/resource_cloudstack_instance.go
@@ -329,11 +329,11 @@ func resourceCloudStackInstanceRead(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	// If we found the root disk, then update it's size.
+	// If we found the root disk, then update its size.
 	if len(l.Volumes) != 1 {
 		log.Printf("[DEBUG] Failed to find root disk of instance: %s", vm.Name)
 	} else {
-		d.Set("root_disk_size", l.Volumes[0].Size)
+		d.Set("root_disk_size", l.Volumes[0].Size>>30) // B to GiB
 	}
 
 	if _, ok := d.GetOk("affinity_group_ids"); ok {


### PR DESCRIPTION
When doing a plan.
```
-/+ cloudstack_instance.test (new resource required)
 [...]
 root_disk_size:                  "10737418240" => "10" (forces new resource)
 [...]
```

- `ListVolumes` size is in Byte, https://github.com/apache/cloudstack/blob/4627fb2cd7556173bd7e58bf1bec22c93a78f31d/api/src/org/apache/cloudstack/api/response/VolumeResponse.java#L102-L104
- `DeployVM` size is in GiB, https://github.com/apache/cloudstack/blob/4627fb2cd7556173bd7e58bf1bec22c93a78f31d/api/src/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java#L117-L121

(cc @jpmenil)

Regression introduced by #28
