### PR TITLE
Add secondary IP address output to create function

### DIFF
--- a/cloudstack/resource_cloudstack_secondary_ipaddress.go
+++ b/cloudstack/resource_cloudstack_secondary_ipaddress.go
@@ -75,7 +75,7 @@ func resourceCloudStackSecondaryIPAddressCreate(d *schema.ResourceData, meta int
 
 	d.SetId(ip.Id)
 
-	return nil
+	return resourceCloudStackSecondaryIPAddressRead(d, meta)
 }
 
 func resourceCloudStackSecondaryIPAddressRead(d *schema.ResourceData, meta interface{}) error {

--- a/website/docs/r/secondary_ipaddress.html.markdown
+++ b/website/docs/r/secondary_ipaddress.html.markdown
@@ -39,3 +39,4 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The secondary IP address ID.
+* `ip_address` - The IP address that was acquired and associated.


### PR DESCRIPTION
We have a use case requiring the creation of a secondary IP and adding it to a DNS record. To my surprise the secondary IP creation doesn't output the created IP as an attribute, whereas the non-secondary does. After comparing the two, I settled with the simple solution of returning the read function upon creation.