### PR TITLE
disk: Read attach field using volume's Virtualmachineid

### DIFF
--- a/cloudstack/resource_cloudstack_disk.go
+++ b/cloudstack/resource_cloudstack_disk.go
@@ -166,7 +166,7 @@ func resourceCloudStackDiskRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	d.Set("name", v.Name)
-	d.Set("attach", v.Attached != "")           // If attached this contains a timestamp when attached
+	d.Set("attach", v.Virtualmachineid != "")   // If attached this contains a virtual machine ID
 	d.Set("size", int(v.Size/(1024*1024*1024))) // Needed to get GB's again
 
 	tags := make(map[string]interface{})
@@ -179,7 +179,7 @@ func resourceCloudStackDiskRead(d *schema.ResourceData, meta interface{}) error 
 	setValueOrID(d, "project", v.Project, v.Projectid)
 	setValueOrID(d, "zone", v.Zonename, v.Zoneid)
 
-	if v.Attached != "" {
+	if v.Virtualmachineid != "" {
 		d.Set("device_id", int(v.Deviceid))
 		d.Set("virtual_machine_id", v.Virtualmachineid)
 	}
@@ -382,7 +382,7 @@ func isAttached(d *schema.ResourceData, meta interface{}) (bool, error) {
 		return false, err
 	}
 
-	return v.Attached != "", nil
+	return v.Virtualmachineid != "", nil
 }
 
 func retryableAttachVolumeFunc(


### PR DESCRIPTION
The `.Attached` field is unreliable, there are situations where cloudstack will return an empty `.Attached` value even if the disk is attached to a VM. So far I've seem this happen when the disk is created alongside with the virtualmachine (deployVirtualMachine called with the `size` attribute) but there may be other situations where this also happens.

Checking for the `.Virtualmachineid` field to set the `attach` attribute seems a safer approach as it's always set when the volume is already attached.

I came across this when importing an existing infrastructure to terraform by manually creating a state file, the existing VMs have attached volumes that were created with them and these volumes don't have a `.Attached` field. This causes the cloudstack provider to try to attach them to the same VMs they are already attached, raising an error.