### PR TITLE
Add ImportStatePassthrough to resources

### DIFF
--- a/cloudstack/resource_cloudstack_affinity_group.go
+++ b/cloudstack/resource_cloudstack_affinity_group.go
@@ -14,6 +14,9 @@ func resourceCloudStackAffinityGroup() *schema.Resource {
 		Create: resourceCloudStackAffinityGroupCreate,
 		Read:   resourceCloudStackAffinityGroupRead,
 		Delete: resourceCloudStackAffinityGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/cloudstack/resource_cloudstack_disk.go
+++ b/cloudstack/resource_cloudstack_disk.go
@@ -14,6 +14,9 @@ func resourceCloudStackDisk() *schema.Resource {
 		Read:   resourceCloudStackDiskRead,
 		Update: resourceCloudStackDiskUpdate,
 		Delete: resourceCloudStackDiskDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/cloudstack/resource_cloudstack_egress_firewall.go
+++ b/cloudstack/resource_cloudstack_egress_firewall.go
@@ -18,6 +18,9 @@ func resourceCloudStackEgressFirewall() *schema.Resource {
 		Read:   resourceCloudStackEgressFirewallRead,
 		Update: resourceCloudStackEgressFirewallUpdate,
 		Delete: resourceCloudStackEgressFirewallDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"network_id": &schema.Schema{

--- a/cloudstack/resource_cloudstack_firewall.go
+++ b/cloudstack/resource_cloudstack_firewall.go
@@ -18,6 +18,9 @@ func resourceCloudStackFirewall() *schema.Resource {
 		Read:   resourceCloudStackFirewallRead,
 		Update: resourceCloudStackFirewallUpdate,
 		Delete: resourceCloudStackFirewallDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"ip_address_id": &schema.Schema{

--- a/cloudstack/resource_cloudstack_instance.go
+++ b/cloudstack/resource_cloudstack_instance.go
@@ -18,6 +18,9 @@ func resourceCloudStackInstance() *schema.Resource {
 		Read:   resourceCloudStackInstanceRead,
 		Update: resourceCloudStackInstanceUpdate,
 		Delete: resourceCloudStackInstanceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/cloudstack/resource_cloudstack_ipaddress.go
+++ b/cloudstack/resource_cloudstack_ipaddress.go
@@ -14,6 +14,9 @@ func resourceCloudStackIPAddress() *schema.Resource {
 		Create: resourceCloudStackIPAddressCreate,
 		Read:   resourceCloudStackIPAddressRead,
 		Delete: resourceCloudStackIPAddressDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"is_portable": &schema.Schema{

--- a/cloudstack/resource_cloudstack_loadbalancer_rule.go
+++ b/cloudstack/resource_cloudstack_loadbalancer_rule.go
@@ -15,6 +15,9 @@ func resourceCloudStackLoadBalancerRule() *schema.Resource {
 		Read:   resourceCloudStackLoadBalancerRuleRead,
 		Update: resourceCloudStackLoadBalancerRuleUpdate,
 		Delete: resourceCloudStackLoadBalancerRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/cloudstack/resource_cloudstack_network.go
+++ b/cloudstack/resource_cloudstack_network.go
@@ -37,6 +37,9 @@ func resourceCloudStackNetwork() *schema.Resource {
 		Read:   resourceCloudStackNetworkRead,
 		Update: resourceCloudStackNetworkUpdate,
 		Delete: resourceCloudStackNetworkDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/cloudstack/resource_cloudstack_network_acl.go
+++ b/cloudstack/resource_cloudstack_network_acl.go
@@ -14,6 +14,9 @@ func resourceCloudStackNetworkACL() *schema.Resource {
 		Create: resourceCloudStackNetworkACLCreate,
 		Read:   resourceCloudStackNetworkACLRead,
 		Delete: resourceCloudStackNetworkACLDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/cloudstack/resource_cloudstack_network_acl_rule.go
+++ b/cloudstack/resource_cloudstack_network_acl_rule.go
@@ -19,6 +19,9 @@ func resourceCloudStackNetworkACLRule() *schema.Resource {
 		Read:   resourceCloudStackNetworkACLRuleRead,
 		Update: resourceCloudStackNetworkACLRuleUpdate,
 		Delete: resourceCloudStackNetworkACLRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"acl_id": &schema.Schema{

--- a/cloudstack/resource_cloudstack_nic.go
+++ b/cloudstack/resource_cloudstack_nic.go
@@ -14,6 +14,9 @@ func resourceCloudStackNIC() *schema.Resource {
 		Create: resourceCloudStackNICCreate,
 		Read:   resourceCloudStackNICRead,
 		Delete: resourceCloudStackNICDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"network_id": &schema.Schema{

--- a/cloudstack/resource_cloudstack_port_forward.go
+++ b/cloudstack/resource_cloudstack_port_forward.go
@@ -19,6 +19,9 @@ func resourceCloudStackPortForward() *schema.Resource {
 		Read:   resourceCloudStackPortForwardRead,
 		Update: resourceCloudStackPortForwardUpdate,
 		Delete: resourceCloudStackPortForwardDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"ip_address_id": &schema.Schema{

--- a/cloudstack/resource_cloudstack_private_gateway.go
+++ b/cloudstack/resource_cloudstack_private_gateway.go
@@ -15,6 +15,9 @@ func resourceCloudStackPrivateGateway() *schema.Resource {
 		Read:   resourceCloudStackPrivateGatewayRead,
 		Update: resourceCloudStackPrivateGatewayUpdate,
 		Delete: resourceCloudStackPrivateGatewayDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"gateway": &schema.Schema{

--- a/cloudstack/resource_cloudstack_secondary_ipaddress.go
+++ b/cloudstack/resource_cloudstack_secondary_ipaddress.go
@@ -14,6 +14,9 @@ func resourceCloudStackSecondaryIPAddress() *schema.Resource {
 		Create: resourceCloudStackSecondaryIPAddressCreate,
 		Read:   resourceCloudStackSecondaryIPAddressRead,
 		Delete: resourceCloudStackSecondaryIPAddressDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"ip_address": &schema.Schema{

--- a/cloudstack/resource_cloudstack_security_group.go
+++ b/cloudstack/resource_cloudstack_security_group.go
@@ -14,6 +14,9 @@ func resourceCloudStackSecurityGroup() *schema.Resource {
 		Create: resourceCloudStackSecurityGroupCreate,
 		Read:   resourceCloudStackSecurityGroupRead,
 		Delete: resourceCloudStackSecurityGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/cloudstack/resource_cloudstack_security_group_rule.go
+++ b/cloudstack/resource_cloudstack_security_group_rule.go
@@ -30,6 +30,9 @@ func resourceCloudStackSecurityGroupRule() *schema.Resource {
 		Read:   resourceCloudStackSecurityGroupRuleRead,
 		Update: resourceCloudStackSecurityGroupRuleUpdate,
 		Delete: resourceCloudStackSecurityGroupRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"security_group_id": &schema.Schema{

--- a/cloudstack/resource_cloudstack_ssh_keypair.go
+++ b/cloudstack/resource_cloudstack_ssh_keypair.go
@@ -14,6 +14,9 @@ func resourceCloudStackSSHKeyPair() *schema.Resource {
 		Create: resourceCloudStackSSHKeyPairCreate,
 		Read:   resourceCloudStackSSHKeyPairRead,
 		Delete: resourceCloudStackSSHKeyPairDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/cloudstack/resource_cloudstack_static_nat.go
+++ b/cloudstack/resource_cloudstack_static_nat.go
@@ -15,6 +15,9 @@ func resourceCloudStackStaticNAT() *schema.Resource {
 		Exists: resourceCloudStackStaticNATExists,
 		Read:   resourceCloudStackStaticNATRead,
 		Delete: resourceCloudStackStaticNATDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"ip_address_id": &schema.Schema{

--- a/cloudstack/resource_cloudstack_static_route.go
+++ b/cloudstack/resource_cloudstack_static_route.go
@@ -14,6 +14,9 @@ func resourceCloudStackStaticRoute() *schema.Resource {
 		Create: resourceCloudStackStaticRouteCreate,
 		Read:   resourceCloudStackStaticRouteRead,
 		Delete: resourceCloudStackStaticRouteDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"cidr": &schema.Schema{

--- a/cloudstack/resource_cloudstack_template.go
+++ b/cloudstack/resource_cloudstack_template.go
@@ -16,6 +16,9 @@ func resourceCloudStackTemplate() *schema.Resource {
 		Read:   resourceCloudStackTemplateRead,
 		Update: resourceCloudStackTemplateUpdate,
 		Delete: resourceCloudStackTemplateDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/cloudstack/resource_cloudstack_vpc.go
+++ b/cloudstack/resource_cloudstack_vpc.go
@@ -15,6 +15,9 @@ func resourceCloudStackVPC() *schema.Resource {
 		Read:   resourceCloudStackVPCRead,
 		Update: resourceCloudStackVPCUpdate,
 		Delete: resourceCloudStackVPCDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/cloudstack/resource_cloudstack_vpn_connection.go
+++ b/cloudstack/resource_cloudstack_vpn_connection.go
@@ -14,6 +14,9 @@ func resourceCloudStackVPNConnection() *schema.Resource {
 		Create: resourceCloudStackVPNConnectionCreate,
 		Read:   resourceCloudStackVPNConnectionRead,
 		Delete: resourceCloudStackVPNConnectionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"customer_gateway_id": &schema.Schema{

--- a/cloudstack/resource_cloudstack_vpn_customer_gateway.go
+++ b/cloudstack/resource_cloudstack_vpn_customer_gateway.go
@@ -15,6 +15,9 @@ func resourceCloudStackVPNCustomerGateway() *schema.Resource {
 		Read:   resourceCloudStackVPNCustomerGatewayRead,
 		Update: resourceCloudStackVPNCustomerGatewayUpdate,
 		Delete: resourceCloudStackVPNCustomerGatewayDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/cloudstack/resource_cloudstack_vpn_gateway.go
+++ b/cloudstack/resource_cloudstack_vpn_gateway.go
@@ -14,6 +14,9 @@ func resourceCloudStackVPNGateway() *schema.Resource {
 		Create: resourceCloudStackVPNGatewayCreate,
 		Read:   resourceCloudStackVPNGatewayRead,
 		Delete: resourceCloudStackVPNGatewayDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"vpc_id": &schema.Schema{


### PR DESCRIPTION
This should work fine, allowing users to run an import towards all resources based on their existing UUID, for example:

```
terraform import cloudstack_vpc.my_vpc <id>
```

Tested with Apache CloudStack 4.11 and Cosmic 6.1.14, with both local tfstate files and S3 as backend.
