### PR TITLE
Add cloudstack_autoscale_vm_profile resource

### DIFF
--- a/cloudstack/metadata.go
+++ b/cloudstack/metadata.go
@@ -1,0 +1,92 @@
+package cloudstack
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/xanzy/go-cloudstack/cloudstack"
+)
+
+// metadataSchema returns the schema to use for metadata
+func metadataSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeMap,
+		Optional: true,
+		Computed: true,
+	}
+}
+
+// setMetadata is a helper to set the metadata for a resource. It expects the
+// metadata field to be named "metadata"
+func setMetadata(cs *cloudstack.CloudStackClient, d *schema.ResourceData, resourceType string) error {
+	if metadata, ok := d.GetOk("metadata"); ok {
+		p := cs.Resourcemetadata.NewAddResourceDetailParams(
+			tagsFromSchema(metadata.(map[string]interface{})),
+			d.Id(), resourceType,
+		)
+		_, err := cs.Resourcemetadata.AddResourceDetail(p)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getMetadata(cs *cloudstack.CloudStackClient, d *schema.ResourceData, resourceType string) (map[string]interface{}, error) {
+	p := cs.Resourcemetadata.NewListResourceDetailsParams(resourceType)
+	p.SetResourceid(d.Id())
+	response, err := cs.Resourcemetadata.ListResourceDetails(p)
+	if err != nil {
+		return nil, err
+	}
+	// Only return metadata values that were explicitely set
+	var existingFilter map[string]interface{}
+	if metadata, ok := d.GetOk("metadata"); ok {
+		existingFilter = metadata.(map[string]interface{})
+	}
+	metadata := make(map[string]interface{}, response.Count)
+	for _, detail := range response.ResourceDetails {
+		if _, ok := existingFilter[detail.Key]; ok {
+			metadata[detail.Key] = detail.Value
+		}
+	}
+	return metadata, nil
+}
+
+// updateMetadata is a helper to update only when metadata field change metadata
+// field to be named "metadata"
+func updateMetadata(cs *cloudstack.CloudStackClient, d *schema.ResourceData, resourceType string) error {
+	oraw, nraw := d.GetChange("metadata")
+	o := oraw.(map[string]interface{})
+	n := nraw.(map[string]interface{})
+
+	remove, create := diffTags(tagsFromSchema(o), tagsFromSchema(n))
+	log.Printf("[DEBUG] metadata to remove: %v", remove)
+	log.Printf("[DEBUG] metadata to create: %v", create)
+
+	// First remove any obsolete metadata
+	if len(remove) > 0 {
+		log.Printf("[DEBUG] Removing metadata: %v from %s", remove, d.Id())
+		p := cs.Resourcemetadata.NewRemoveResourceDetailParams(d.Id(), resourceType)
+		for key := range remove {
+			p.SetKey(key)
+			_, err := cs.Resourcemetadata.RemoveResourceDetail(p)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// Then add any new metadata
+	if len(create) > 0 {
+		log.Printf("[DEBUG] Creating metadata: %v for %s", create, d.Id())
+		p := cs.Resourcemetadata.NewAddResourceDetailParams(create, d.Id(), resourceType)
+		_, err := cs.Resourcemetadata.AddResourceDetail(p)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cloudstack/provider.go
+++ b/cloudstack/provider.go
@@ -64,6 +64,7 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"cloudstack_affinity_group":       resourceCloudStackAffinityGroup(),
+			"cloudstack_autoscale_vm_profile": resourceCloudStackAutoScaleVMProfile(),
 			"cloudstack_disk":                 resourceCloudStackDisk(),
 			"cloudstack_egress_firewall":      resourceCloudStackEgressFirewall(),
 			"cloudstack_firewall":             resourceCloudStackFirewall(),

--- a/cloudstack/resource_cloudstack_autoscale_vm_profile.go
+++ b/cloudstack/resource_cloudstack_autoscale_vm_profile.go
@@ -1,0 +1,232 @@
+package cloudstack
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/xanzy/go-cloudstack/cloudstack"
+)
+
+func resourceCloudStackAutoScaleVMProfile() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudStackAutoScaleVMProfileCreate,
+		Read:   resourceCloudStackAutoScaleVMProfileRead,
+		Update: resourceCloudStackAutoScaleVMProfileUpdate,
+		Delete: resourceCloudStackAutoScaleVMProfileDelete,
+
+		Schema: map[string]*schema.Schema{
+			"zone": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"service_offering": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"template": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"other_deploy_params": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"destroy_vm_grace_period": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"metadata": metadataSchema(),
+		},
+	}
+}
+
+func resourceCloudStackAutoScaleVMProfileCreate(d *schema.ResourceData, meta interface{}) error {
+	cs := meta.(*cloudstack.CloudStackClient)
+
+	// Retrieve the service_offering ID
+	serviceofferingid, e := retrieveID(cs, "service_offering", d.Get("service_offering").(string))
+	if e != nil {
+		return e.Error()
+	}
+
+	// Retrieve the zone ID
+	zoneid, e := retrieveID(cs, "zone", d.Get("zone").(string))
+	if e != nil {
+		return e.Error()
+	}
+
+	// Retrieve the template ID
+	templateid, e := retrieveTemplateID(cs, zoneid, d.Get("template").(string))
+	if e != nil {
+		return e.Error()
+	}
+
+	p := cs.AutoScale.NewCreateAutoScaleVmProfileParams(serviceofferingid, templateid, zoneid)
+
+	if v, ok := d.GetOk("other_deploy_params"); ok {
+		otherMap := v.(map[string]interface{})
+		result := url.Values{}
+		for k, v := range otherMap {
+			result.Set(k, fmt.Sprint(v))
+		}
+		p.SetOtherdeployparams(result.Encode())
+	}
+
+	if v, ok := d.GetOk("destroy_vm_grace_period"); ok {
+		duration, err := time.ParseDuration(v.(string))
+		if err != nil {
+			return err
+		}
+		p.SetDestroyvmgraceperiod(int(duration.Seconds()))
+	}
+
+	// Create the new vm profile
+	r, err := cs.AutoScale.CreateAutoScaleVmProfile(p)
+	if err != nil {
+		return fmt.Errorf("Error creating AutoScaleVmProfile %s: %s", d.Id(), err)
+	}
+
+	d.SetId(r.Id)
+
+	// Set metadata if necessary
+	if err = setMetadata(cs, d, "AutoScaleVmProfile"); err != nil {
+		return fmt.Errorf("Error setting metadata on the AutoScaleVmProfile %s: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceCloudStackAutoScaleVMProfileRead(d *schema.ResourceData, meta interface{}) error {
+	cs := meta.(*cloudstack.CloudStackClient)
+
+	p, count, err := cs.AutoScale.GetAutoScaleVmProfileByID(d.Id())
+
+	if err != nil {
+		if count == 0 {
+			log.Printf(
+				"[DEBUG] AutoScaleVmProfile %s no longer exists", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	zone, _, err := cs.Zone.GetZoneByID(p.Zoneid)
+	if err != nil {
+		return err
+	}
+
+	offering, _, err := cs.ServiceOffering.GetServiceOfferingByID(p.Serviceofferingid)
+	if err != nil {
+		return err
+	}
+
+	template, _, err := cs.Template.GetTemplateByID(p.Templateid, "executable")
+	if err != nil {
+		return err
+	}
+
+	setValueOrID(d, "zone", zone.Name, p.Zoneid)
+	setValueOrID(d, "service_offering", offering.Name, p.Serviceofferingid)
+	setValueOrID(d, "template", template.Name, p.Templateid)
+
+	if p.Otherdeployparams != "" {
+		var values url.Values
+		values, err = url.ParseQuery(p.Otherdeployparams)
+		if err != nil {
+			return err
+		}
+		otherParams := make(map[string]interface{}, len(values))
+		for key := range values {
+			otherParams[key] = values.Get(key)
+		}
+		d.Set("other_deploy_params", otherParams)
+	}
+
+	d.Set("destroy_vm_grace_period", (time.Duration(p.Destroyvmgraceperiod) * time.Second).String())
+
+	metadata, err := getMetadata(cs, d, "AutoScaleVmProfile")
+	if err != nil {
+		return err
+	}
+	d.Set("metadata", metadata)
+
+	return nil
+}
+
+func resourceCloudStackAutoScaleVMProfileUpdate(d *schema.ResourceData, meta interface{}) error {
+	cs := meta.(*cloudstack.CloudStackClient)
+
+	// Create a new parameter struct
+	p := cs.AutoScale.NewUpdateAutoScaleVmProfileParams(d.Id())
+
+	if d.HasChange("template") {
+		zoneid, e := retrieveID(cs, "zone", d.Get("zone").(string))
+		if e != nil {
+			return e.Error()
+		}
+		templateid, e := retrieveTemplateID(cs, zoneid, d.Get("template").(string))
+		if e != nil {
+			return e.Error()
+		}
+		p.SetTemplateid(templateid)
+	}
+
+	if d.HasChange("destroy_vm_grace_period") {
+		duration, err := time.ParseDuration(d.Get("destroy_vm_grace_period").(string))
+		if err != nil {
+			return err
+		}
+		p.SetDestroyvmgraceperiod(int(duration.Seconds()))
+	}
+
+	_, err := cs.AutoScale.UpdateAutoScaleVmProfile(p)
+	if err != nil {
+		return fmt.Errorf("Error updating AutoScaleVmProfile %s: %s", d.Id(), err)
+	}
+
+	if d.HasChange("metadata") {
+		if err := updateMetadata(cs, d, "AutoScaleVmProfile"); err != nil {
+			return fmt.Errorf("Error updating tags on AutoScaleVmProfile %s: %s", d.Id(), err)
+		}
+	}
+
+	return resourceCloudStackAutoScaleVMProfileRead(d, meta)
+}
+
+func resourceCloudStackAutoScaleVMProfileDelete(d *schema.ResourceData, meta interface{}) error {
+	cs := meta.(*cloudstack.CloudStackClient)
+
+	// Create a new parameter struct
+	p := cs.AutoScale.NewDeleteAutoScaleVmProfileParams(d.Id())
+
+	// Delete the template
+	log.Printf("[INFO] Deleting AutoScaleVmProfile: %s", d.Id())
+	_, err := cs.AutoScale.DeleteAutoScaleVmProfile(p)
+	if err != nil {
+		// This is a very poor way to be told the ID does no longer exist :(
+		if strings.Contains(err.Error(), fmt.Sprintf(
+			"Invalid parameter id value=%s due to incorrect long value format, "+
+				"or entity does not exist", d.Id())) {
+			return nil
+		}
+
+		return fmt.Errorf("Error deleting AutoScaleVmProfile %s: %s", d.Id(), err)
+	}
+	return nil
+}

--- a/cloudstack/resource_cloudstack_autoscale_vm_profile_test.go
+++ b/cloudstack/resource_cloudstack_autoscale_vm_profile_test.go
@@ -1,0 +1,207 @@
+package cloudstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/xanzy/go-cloudstack/cloudstack"
+)
+
+func TestAccCloudStackAutoscaleVMProfile_basic(t *testing.T) {
+	var vmProfile cloudstack.AutoScaleVmProfile
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackAutoscaleVMProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudStackAutoscaleVMProfile_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackAutoscaleVMProfileExists("cloudstack_autoscale_vm_profile.foo", &vmProfile),
+					testAccCheckCloudStackAutoscaleVMProfileBasicAttributes(&vmProfile),
+					resource.TestCheckResourceAttr(
+						"cloudstack_autoscale_vm_profile.foo", "zone", "Sandbox-simulator"),
+					testAccCheckResourceMetadata(&vmProfile),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudStackAutoscaleVMProfile_update(t *testing.T) {
+	var vmProfile cloudstack.AutoScaleVmProfile
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackAutoscaleVMProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudStackAutoscaleVMProfile_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackAutoscaleVMProfileExists("cloudstack_autoscale_vm_profile.foo", &vmProfile),
+					testAccCheckCloudStackAutoscaleVMProfileBasicAttributes(&vmProfile),
+				),
+			},
+
+			{
+				Config: testAccCloudStackAutoscaleVMProfile_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackAutoscaleVMProfileExists(
+						"cloudstack_autoscale_vm_profile.foo", &vmProfile),
+					testAccCheckCloudStackAutoscaleVMProfileUpdatedAttributes(&vmProfile),
+					resource.TestCheckResourceAttr(
+						"cloudstack_autoscale_vm_profile.foo", "zone", "Sandbox-simulator"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckResourceMetadata(vmProfile *cloudstack.AutoScaleVmProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		cs := testAccProvider.Meta().(*cloudstack.CloudStackClient)
+		p := cs.Resourcemetadata.NewListResourceDetailsParams("AutoScaleVmProfile")
+		p.SetResourceid(vmProfile.Id)
+		response, err := cs.Resourcemetadata.ListResourceDetails(p)
+		if err != nil {
+			return err
+		}
+		metadata := make(map[string]string)
+		for _, item := range response.ResourceDetails {
+			metadata[item.Key] = item.Value
+		}
+		return testAccCheckTags(metadata, "terraform-meta", "true")
+	}
+}
+
+func testAccCheckCloudStackAutoscaleVMProfileExists(
+	n string, vmProfile *cloudstack.AutoScaleVmProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No vmProfile ID is set")
+		}
+
+		cs := testAccProvider.Meta().(*cloudstack.CloudStackClient)
+		avp, _, err := cs.AutoScale.GetAutoScaleVmProfileByID(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if avp.Id != rs.Primary.ID {
+			return fmt.Errorf("AutoScaleVMProfile not found")
+		}
+
+		*vmProfile = *avp
+
+		return nil
+	}
+}
+
+func testAccCheckCloudStackAutoscaleVMProfileBasicAttributes(
+	vmProfile *cloudstack.AutoScaleVmProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		cs := testAccProvider.Meta().(*cloudstack.CloudStackClient)
+		zoneid, e := retrieveID(cs, "zone", "Sandbox-simulator")
+		if e != nil {
+			return e.Error()
+		}
+
+		serviceofferingid, e := retrieveID(cs, "service_offering", "Small Instance")
+		if e != nil {
+			return e.Error()
+		}
+
+		templateid, e := retrieveTemplateID(cs, zoneid, "CentOS 5.6 (64-bit) no GUI (Simulator)")
+		if e != nil {
+			return e.Error()
+		}
+
+		if vmProfile.Zoneid != zoneid {
+			return fmt.Errorf("Bad zone: %s", vmProfile.Zoneid)
+		}
+
+		if vmProfile.Serviceofferingid != serviceofferingid {
+			return fmt.Errorf("Bad offering: %s", vmProfile.Serviceofferingid)
+		}
+
+		if vmProfile.Templateid != templateid {
+			return fmt.Errorf("Bad template: %s", vmProfile.Templateid)
+		}
+
+		if vmProfile.Otherdeployparams != "displayname=display1&networkids=net1" {
+			return fmt.Errorf("Bad otherdeployparams: %s", vmProfile.Otherdeployparams)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckCloudStackAutoscaleVMProfileUpdatedAttributes(
+	vmProfile *cloudstack.AutoScaleVmProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if vmProfile.Destroyvmgraceperiod != 10 {
+			return fmt.Errorf("Bad destroy_vm_grace_period: %d", vmProfile.Destroyvmgraceperiod)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckCloudStackAutoscaleVMProfileDestroy(s *terraform.State) error {
+	cs := testAccProvider.Meta().(*cloudstack.CloudStackClient)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudstack_autoscale_vm_profile" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No vmProfile ID is set")
+		}
+
+		_, _, err := cs.AutoScale.GetAutoScaleVmProfileByID(rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("AutoScaleVMProfile %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+var testAccCloudStackAutoscaleVMProfile_basic = `
+resource "cloudstack_autoscale_vm_profile" "foo" {
+  zone = "Sandbox-simulator"
+  service_offering = "Small Instance"
+  template = "CentOS 5.6 (64-bit) no GUI (Simulator)"
+  other_deploy_params = {
+    networkids = "net1"
+    displayname = "display1"
+  }
+  metadata = {
+    terraform-meta = "true"
+  }
+}`
+
+var testAccCloudStackAutoscaleVMProfile_update = `
+resource "cloudstack_autoscale_vm_profile" "foo" {
+  zone = "Sandbox-simulator"
+  service_offering = "Small Instance"
+  template = "CentOS 5.6 (64-bit) no GUI (Simulator)"
+  destroy_vm_grace_period = "10s"
+  other_deploy_params = {
+    networkids = "net1"
+    displayname = "display1"
+  }
+}`

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/terraform v0.12.0
 	github.com/smartystreets/goconvey v0.0.0-20181108003508-044398e4856c // indirect
-	github.com/xanzy/go-cloudstack v0.0.0-20190526095453-42f262b63ed0
+	github.com/xanzy/go-cloudstack v0.0.0-20190908072532-ea9e2fe8176a
 	gopkg.in/ini.v1 v1.40.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -359,8 +359,8 @@ github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4A
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/xanzy/go-cloudstack v0.0.0-20190526095453-42f262b63ed0 h1:NJrcIkdzq0C3I8ypAZwFE9RHtGbfp+mJvqIcoFATZuk=
-github.com/xanzy/go-cloudstack v0.0.0-20190526095453-42f262b63ed0/go.mod h1:sBh287mCRwCz6zyXHMmw7sSZGPohVpnx+o+OY4M+i3A=
+github.com/xanzy/go-cloudstack v0.0.0-20190908072532-ea9e2fe8176a h1:IrNhg1D8fz6LRxxQYySD//Ov3W7+OKZgbm6RZuftFxQ=
+github.com/xanzy/go-cloudstack v0.0.0-20190908072532-ea9e2fe8176a/go.mod h1:sBh287mCRwCz6zyXHMmw7sSZGPohVpnx+o+OY4M+i3A=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/GuestOSService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/GuestOSService.go
@@ -36,7 +36,8 @@ func (p *AddGuestOsParams) toURLValues() url.Values {
 	if v, found := p.p["details"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
 			i++
 		}
 	}
@@ -969,7 +970,8 @@ func (p *UpdateGuestOsParams) toURLValues() url.Values {
 	if v, found := p.p["details"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
 			i++
 		}
 	}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/ImageStoreService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/ImageStoreService.go
@@ -36,7 +36,8 @@ func (p *AddImageStoreParams) toURLValues() url.Values {
 	if v, found := p.p["details"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
 			i++
 		}
 	}
@@ -323,7 +324,8 @@ func (p *CreateSecondaryStagingStoreParams) toURLValues() url.Values {
 	if v, found := p.p["details"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
 			i++
 		}
 	}
@@ -1045,7 +1047,8 @@ func (p *UpdateCloudToUseObjectStoreParams) toURLValues() url.Values {
 	if v, found := p.p["details"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
 			i++
 		}
 	}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/ResourcemetadataService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/ResourcemetadataService.go
@@ -35,7 +35,8 @@ func (p *AddResourceDetailParams) toURLValues() url.Values {
 	if v, found := p.p["details"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
 			i++
 		}
 	}

--- a/vendor/github.com/xanzy/go-cloudstack/cloudstack/ZoneService.go
+++ b/vendor/github.com/xanzy/go-cloudstack/cloudstack/ZoneService.go
@@ -1109,7 +1109,8 @@ func (p *UpdateZoneParams) toURLValues() url.Values {
 	if v, found := p.p["details"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
 			i++
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -215,7 +215,7 @@ github.com/ulikunitz/xz/internal/hash
 # github.com/vmihailenco/msgpack v4.0.1+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/xanzy/go-cloudstack v0.0.0-20190526095453-42f262b63ed0
+# github.com/xanzy/go-cloudstack v0.0.0-20190908072532-ea9e2fe8176a
 github.com/xanzy/go-cloudstack/cloudstack
 # github.com/zclconf/go-cty v0.0.0-20190516203816-4fecf87372ec
 github.com/zclconf/go-cty/cty

--- a/website/cloudstack.erb
+++ b/website/cloudstack.erb
@@ -26,6 +26,10 @@
                         <a href="/docs/providers/cloudstack/r/affinity_group.html">cloudstack_affinity_group</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-cloudstack-resource-autoscale-vm-profile") %>>
+                            <a href="/docs/providers/cloudstack/r/autoscale_vm_profile.html">cloudstack_autoscale_vm_profile</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-cloudstack-resource-disk") %>>
                         <a href="/docs/providers/cloudstack/r/disk.html">cloudstack_disk</a>
                         </li>

--- a/website/docs/r/autoscale_vm_profile.html.markdown
+++ b/website/docs/r/autoscale_vm_profile.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "cloudstack"
+page_title: "CloudStack: cloudstack_autoscale_vm_profile"
+sidebar_current: "docs-cloudstack-autoscale-vm-profile"
+description: |-
+  Creates an autoscale VM profile.
+---
+
+# cloudstack_autoscale_vm_profile
+
+Creates an autoscale VM profile.
+
+## Example Usage
+
+```hcl
+resource "cloudstack_autoscale_vm_profile" "profile1" {
+  service_offering        = "small"
+  template                = "CentOS 6.5"
+  zone                    = "zone-1"
+  destroy_vm_grace_period = "45s"
+  
+  other_deploy_params = {
+    networkids  = "6eb22f91-7454-4107-89f4-36afcdf33021"
+    displayname = "profile1vm"
+  }
+
+  metadata = {
+    mydata = "true"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_offering` - (Required) The name or ID of the service offering used
+    for instances. Changing this forces a new resource to be created.
+
+* `template` - (Required) The name or ID of the template used for instances.
+
+* `zone` - (Required) The name or ID of the zone where instances will be
+    created. Changing this forces a new resource to be created.
+
+* `destroy_vm_grace_period` - (Optional) A time interval to wait for graceful
+    shutdown of instances.
+
+* `other_deploy_params` - (Optional) A mapping of additional params used when
+    creating new instances.
+
+* `metadata` - (Optional) A mapping of metadata key/values to assign to the
+    resource.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The autoscale VM profile ID.


### PR DESCRIPTION
This PR adds a new resource: `cloudstack_autoscale_vm_profile`. Creating a `cloudstack_autoscale_vm_profile` creates an `AutoScaleVMProfile` on cloudstack. This new resource also supports additional metadata associated with the `AutoScaleVMProfile`. Metadata works very similarly to Tags but it uses the `resourceDetail` API calls. Metadata are used because `AutoScaleVMProfile` objects do not support tags.

I was able to run the new tests using the simulator locally and they pass. For some reason I had to change the cloudstack config `endpointe.url` to use `127.0.0.1` in the URL instead of `localhost` for the tests to run.

One noteworthy review point is that although the `otherdeployparams` field encoding isn't documented, according to the source code it's supposed to be url form encoded:
https://github.com/apache/cloudstack/blob/87c43501608a1df72a2f01ed17a522233e6617b0/api/src/main/java/org/apache/cloudstack/api/command/user/autoscale/CreateAutoScaleVmProfileCmd.java#L189-L191

